### PR TITLE
refactor(zing): rename method `addRoute` to `route` for consistent naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ process.on('SIGINT', async () => {
 
 - [Zing.listen()](#zinglisten)
 - [Zing.shutdown()](#zingshutdown)
-- [Zing.addRoute()](#zingaddroute)
+- [Zing.route()](#zingroute)
 - [Zing.get()](#zingget)
 - [Zing.head()](#zinghead)
 - [Zing.patch()](#zingpatch)
@@ -139,14 +139,14 @@ await app.shutdown(5000); // Shutdown the server after 5 seconds.
 
 [⬆️ Back to top](#-api)
 
-### Zing.addRoute()
+### Zing.route()
 
 Adds a route to the server.
 
 **Type**
 
 ```ts
-addRoute(method: 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS', pattern: string, handler: (req: Request, res: Response) => Promise<void> |void): void;
+route(method: 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS', pattern: string, handler: (req: Request, res: Response) => Promise<void> |void): void;
 ```
 
 **Parameters**
@@ -162,7 +162,7 @@ addRoute(method: 'GET' | 'HEAD' | 'PATCH' | 'POST' | 'PUT' | 'DELETE' | 'OPTIONS
 **Example**
 
 ```ts
-app.addRoute('GET', '/', (req, res) => {
+app.route('GET', '/', (req, res) => {
   res.ok();
 });
 ```

--- a/src/zing.ts
+++ b/src/zing.ts
@@ -157,7 +157,7 @@ export default class Zing {
    *
    * @throws {Error} If the given pattern is invalid.
    */
-  addRoute(method: HTTPMethod, pattern: string, handler: RouteHandler) {
+  route(method: HTTPMethod, pattern: string, handler: RouteHandler) {
     const result = this.#router.addRoute(method, pattern, { handler });
 
     if (result.isErr()) {
@@ -172,7 +172,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   get(pattern: string, handler: RouteHandler) {
-    this.addRoute('GET', pattern, handler);
+    this.route('GET', pattern, handler);
   }
 
   /**
@@ -182,7 +182,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   head(pattern: string, handler: RouteHandler) {
-    this.addRoute('HEAD', pattern, handler);
+    this.route('HEAD', pattern, handler);
   }
 
   /**
@@ -192,7 +192,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   patch(pattern: string, handler: RouteHandler) {
-    this.addRoute('PATCH', pattern, handler);
+    this.route('PATCH', pattern, handler);
   }
 
   /**
@@ -202,7 +202,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   post(pattern: string, handler: RouteHandler) {
-    this.addRoute('POST', pattern, handler);
+    this.route('POST', pattern, handler);
   }
 
   /**
@@ -212,7 +212,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   put(pattern: string, handler: RouteHandler) {
-    this.addRoute('PUT', pattern, handler);
+    this.route('PUT', pattern, handler);
   }
 
   /**
@@ -222,7 +222,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   delete(pattern: string, handler: RouteHandler) {
-    this.addRoute('DELETE', pattern, handler);
+    this.route('DELETE', pattern, handler);
   }
 
   /**
@@ -232,7 +232,7 @@ export default class Zing {
    * @param handler - The handler to call when the route is matched.
    */
   options(pattern: string, handler: RouteHandler) {
-    this.addRoute('OPTIONS', pattern, handler);
+    this.route('OPTIONS', pattern, handler);
   }
 
   /**

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -12,7 +12,7 @@ describeMatrix('Request', (ctx) => {
         res.ok();
       });
 
-      ctx.app.addRoute('GET', '/protocol', handler);
+      ctx.app.route('GET', '/protocol', handler);
 
       const res = await ctx.request('GET', '/protocol');
 
@@ -54,7 +54,7 @@ describeMatrix('Request', (ctx) => {
           res.ok();
         });
 
-        ctx.app.addRoute(method, `/${method}`, handler);
+        ctx.app.route(method, `/${method}`, handler);
 
         const res = await ctx.request(method, `/${method}`);
 
@@ -560,7 +560,7 @@ describeMatrix('Request', (ctx) => {
           res.ok();
         });
 
-        ctx.app.addRoute(method, '/body', handler);
+        ctx.app.route(method, '/body', handler);
 
         const res = await ctx.request(method, '/body', {
           body: 'foobar',
@@ -619,7 +619,7 @@ describeMatrix('Request', (ctx) => {
           res.ok();
         });
 
-        ctx.app.addRoute(method, '/text', handler);
+        ctx.app.route(method, '/text', handler);
 
         const res = await ctx.request(method, '/text', {
           body: 'foobar',
@@ -705,7 +705,7 @@ describeMatrix('Request', (ctx) => {
           res.ok();
         });
 
-        ctx.app.addRoute(method, '/json', handler);
+        ctx.app.route(method, '/json', handler);
 
         const res = await ctx.request(method, '/json', {
           body: { foo: 'bar' },

--- a/test/zing.test.ts
+++ b/test/zing.test.ts
@@ -3,7 +3,7 @@ import type { ErrorHandler, HTTPMethod, RouteHandler } from '../src/types.js';
 import { describeMatrix } from './_setup.js';
 
 describeMatrix('Zing', (ctx) => {
-  describe('addRoute()', () => {
+  describe('route()', () => {
     test.each<HTTPMethod>(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'])(
       'adds a route for the method `%s`',
       async (method) => {
@@ -11,7 +11,7 @@ describeMatrix('Zing', (ctx) => {
           res.ok();
         });
 
-        ctx.app.addRoute(method, '/', handler);
+        ctx.app.route(method, '/', handler);
 
         const res = await ctx.request(method, '/');
 
@@ -207,7 +207,7 @@ describeMatrix('Zing', (ctx) => {
             throw new Error('Kaboom!');
           });
 
-          ctx.app.addRoute(method, '/kaboom', handler);
+          ctx.app.route(method, '/kaboom', handler);
 
           const res = await ctx.request(method, '/kaboom');
 
@@ -244,7 +244,7 @@ describeMatrix('Zing', (ctx) => {
             throw new Error('Kaboom!');
           });
 
-          ctx.app.addRoute(method, '/kaboom', handler);
+          ctx.app.route(method, '/kaboom', handler);
 
           const errorHandler = vi.fn<ErrorHandler>((_err, _req, res) => {
             res.json(HTTPStatusCode.InternalServerError, {
@@ -299,7 +299,7 @@ describeMatrix('Zing', (ctx) => {
             throw new Error('Kaboom!');
           });
 
-          ctx.app.addRoute(method, '/kaboom', handler);
+          ctx.app.route(method, '/kaboom', handler);
 
           const errorHandler = vi.fn<ErrorHandler>(() => {
             throw new Error('Kaboom again!');


### PR DESCRIPTION
Renamed the `addRoute` method to `route` in the Zing API to align with existing naming conventions and improve consistency across the codebase.