### PR TITLE
refactor(types): rename `RouteHandler` to `Handler` for consistent naming conventions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,11 @@ export { default as Response } from './response.js';
 // Types.
 export type {
   ErrorHandler,
+  Handler,
   HTTPHeaderKey,
   HTTPHeaders,
   HTTPHeaderValue,
   HTTPMethod,
   JSONObject,
   MIME,
-  RouteHandler,
 } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,12 +33,12 @@ export type HTTPHeaders = {
   [Key in HTTPHeaderKey]?: HTTPHeaderValue<Key>;
 };
 
-export type RouteHandler = (req: Request, res: Response) => Promise<void> | void;
-export type ErrorHandler = (err: unknown, req: Request, res: Response) => Promise<void> | void;
-
 type JSONPrimitive = string | number | boolean | null | Date;
 type JSONValue = JSONPrimitive | JSONValue[] | JSONObject;
 
 export interface JSONObject {
   [key: string]: JSONValue;
 }
+
+export type Handler = (req: Request, res: Response) => Promise<void> | void;
+export type ErrorHandler = (err: unknown, req: Request, res: Response) => Promise<void> | void;

--- a/src/zing.ts
+++ b/src/zing.ts
@@ -8,12 +8,12 @@ import { HTTPStatusCode } from './http-status-code.js';
 import Request from './request.js';
 import Response from './response.js';
 import Router from './router.js';
-import type { ErrorHandler, HTTPMethod, RouteHandler } from './types.js';
+import type { ErrorHandler, Handler, HTTPMethod } from './types.js';
 
 /**
  * The default 404 handler.
  */
-const DEFAULT_404_HANDLER: RouteHandler = (_, res) => {
+const DEFAULT_404_HANDLER: Handler = (_, res) => {
   res.text(HTTPStatusCode.NotFound, 'Not Found');
 };
 
@@ -47,11 +47,11 @@ export default class Zing {
   #isListening = false;
   #isShuttingDown = false;
   #activeRequestCountPerSocket = new Map<Socket, number>();
-  #fn404Handler: RouteHandler = DEFAULT_404_HANDLER;
+  #fn404Handler: Handler = DEFAULT_404_HANDLER;
   #fnErrorHandler: ErrorHandler = DEFAULT_ERROR_HANDLER;
 
   #server: HTTPServer;
-  #router: Router<{ handler: RouteHandler }>;
+  #router: Router<{ handler: Handler }>;
 
   constructor() {
     this.#server = createHTTPServer(this.#dispatch.bind(this));
@@ -157,7 +157,7 @@ export default class Zing {
    *
    * @throws {Error} If the given pattern is invalid.
    */
-  route(method: HTTPMethod, pattern: string, handler: RouteHandler) {
+  route(method: HTTPMethod, pattern: string, handler: Handler) {
     const result = this.#router.addRoute(method, pattern, { handler });
 
     if (result.isErr()) {
@@ -171,7 +171,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  get(pattern: string, handler: RouteHandler) {
+  get(pattern: string, handler: Handler) {
     this.route('GET', pattern, handler);
   }
 
@@ -181,7 +181,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  head(pattern: string, handler: RouteHandler) {
+  head(pattern: string, handler: Handler) {
     this.route('HEAD', pattern, handler);
   }
 
@@ -191,7 +191,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  patch(pattern: string, handler: RouteHandler) {
+  patch(pattern: string, handler: Handler) {
     this.route('PATCH', pattern, handler);
   }
 
@@ -201,7 +201,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  post(pattern: string, handler: RouteHandler) {
+  post(pattern: string, handler: Handler) {
     this.route('POST', pattern, handler);
   }
 
@@ -211,7 +211,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  put(pattern: string, handler: RouteHandler) {
+  put(pattern: string, handler: Handler) {
     this.route('PUT', pattern, handler);
   }
 
@@ -221,7 +221,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  delete(pattern: string, handler: RouteHandler) {
+  delete(pattern: string, handler: Handler) {
     this.route('DELETE', pattern, handler);
   }
 
@@ -231,7 +231,7 @@ export default class Zing {
    * @param pattern - The pattern to match the route against.
    * @param handler - The handler to call when the route is matched.
    */
-  options(pattern: string, handler: RouteHandler) {
+  options(pattern: string, handler: Handler) {
     this.route('OPTIONS', pattern, handler);
   }
 
@@ -240,7 +240,7 @@ export default class Zing {
    *
    * @param handler - The handler to call when a route is not found.
    */
-  set404Handler(handler: RouteHandler) {
+  set404Handler(handler: Handler) {
     this.#fn404Handler = handler;
   }
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,4 +1,4 @@
-import type { HTTPMethod, RouteHandler } from '../src/types.js';
+import type { Handler, HTTPMethod } from '../src/types.js';
 import { describeMatrix } from './_setup.js';
 
 describeMatrix('Request', (ctx) => {
@@ -6,7 +6,7 @@ describeMatrix('Request', (ctx) => {
     test('returns the protocol', async () => {
       let actualProtocol: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         actualProtocol = req.protocol;
 
         res.ok();
@@ -26,7 +26,7 @@ describeMatrix('Request', (ctx) => {
     test('returns the pathname', async () => {
       let actualPathname: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         actualPathname = req.pathname;
 
         res.ok();
@@ -48,7 +48,7 @@ describeMatrix('Request', (ctx) => {
       async (method) => {
         let actualMethod: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualMethod = req.method;
 
           res.ok();
@@ -70,7 +70,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the value', async () => {
         let actualValue: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           req.set('foo', 'bar');
           actualValue = req.get('foo');
 
@@ -89,7 +89,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the value even if the default value is provided', async () => {
         let actualValue: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           req.set('foo', 'bar');
           actualValue = req.get('foo', 'qux');
 
@@ -110,7 +110,7 @@ describeMatrix('Request', (ctx) => {
       test('returns `null` if no default value is provided', async () => {
         let actualValue: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualValue = req.get('foo');
 
           res.ok();
@@ -128,7 +128,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the default value if it is provided', async () => {
         let actualValue: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualValue = req.get('foo', 'bar');
 
           res.ok();
@@ -149,7 +149,7 @@ describeMatrix('Request', (ctx) => {
     test('removes the key if the value is `undefined`', async () => {
       let actualValue: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         req.set('foo', 'bar');
         req.set('foo', undefined);
         actualValue = req.get('foo');
@@ -169,7 +169,7 @@ describeMatrix('Request', (ctx) => {
     test('removes the key if the value is `null`', async () => {
       let actualValue: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         req.set('foo', 'bar');
         req.set('foo', null);
         actualValue = req.get('foo');
@@ -192,7 +192,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the parameter value', async () => {
         let actualParam: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualParam = req.param('foo');
 
           res.ok();
@@ -210,7 +210,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the parameter value even if the default value is provided', async () => {
         let actualParam: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualParam = req.param('foo', 'qux');
 
           res.ok();
@@ -230,7 +230,7 @@ describeMatrix('Request', (ctx) => {
       test('returns `null` if no default value is provided', async () => {
         let actualParam: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualParam = req.param('foo');
 
           res.ok();
@@ -248,7 +248,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the default value if it is provided', async () => {
         let actualParam: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualParam = req.param('foo', 'bar');
 
           res.ok();
@@ -270,7 +270,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the query value', async () => {
         let actualQuery: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQuery = req.query('foo');
 
           res.ok();
@@ -288,7 +288,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the query value even if the default value is provided', async () => {
         let actualQuery: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQuery = req.query('foo', 'qux');
 
           res.ok();
@@ -308,7 +308,7 @@ describeMatrix('Request', (ctx) => {
       test('returns `null` if no default value is provided', async () => {
         let actualQuery: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQuery = req.query('foo');
 
           res.ok();
@@ -326,7 +326,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the default value if it is provided', async () => {
         let actualQuery: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQuery = req.query('foo', 'bar');
 
           res.ok();
@@ -345,7 +345,7 @@ describeMatrix('Request', (ctx) => {
     test('returns the value of the first occurrence of the query name', async () => {
       let actualQuery: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         actualQuery = req.query('foo');
 
         res.ok();
@@ -366,7 +366,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the query values', async () => {
         let actualQueries: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQueries = req.queries('foo');
 
           res.ok();
@@ -384,7 +384,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the query values even if the default value is provided', async () => {
         let actualQueries: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQueries = req.queries('foo', ['qux', '123']);
 
           res.ok();
@@ -404,7 +404,7 @@ describeMatrix('Request', (ctx) => {
       test('returns `null` if no default value is provided', async () => {
         let actualQueries: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQueries = req.queries('foo');
 
           res.ok();
@@ -422,7 +422,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the default value if it is provided', async () => {
         let actualQueries: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualQueries = req.queries('foo', ['bar', 'qux']);
 
           res.ok();
@@ -444,7 +444,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the header value', async () => {
         let actualHeader: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualHeader = req.header('foo');
 
           res.ok();
@@ -466,7 +466,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the header value even if it is an array', async () => {
         let actualHeader: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualHeader = req.header('foo', 'qux');
 
           res.ok();
@@ -490,7 +490,7 @@ describeMatrix('Request', (ctx) => {
       test('returns `null` if no default value is provided', async () => {
         let actualHeader: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualHeader = req.header('foo');
 
           res.ok();
@@ -508,7 +508,7 @@ describeMatrix('Request', (ctx) => {
       test('returns the default value if it is provided', async () => {
         let actualHeader: unknown;
 
-        const handler = vi.fn<RouteHandler>((req, res) => {
+        const handler = vi.fn<Handler>((req, res) => {
           actualHeader = req.header('foo', 'bar');
 
           res.ok();
@@ -527,7 +527,7 @@ describeMatrix('Request', (ctx) => {
     test('combines the values of the `set-cookie` header', async () => {
       let actualHeader: unknown;
 
-      const handler = vi.fn<RouteHandler>((req, res) => {
+      const handler = vi.fn<Handler>((req, res) => {
         actualHeader = req.header('set-cookie');
 
         res.ok();
@@ -553,7 +553,7 @@ describeMatrix('Request', (ctx) => {
       async (method) => {
         let actualBody: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.body();
           actualBody = result.unwrap();
 
@@ -584,7 +584,7 @@ describeMatrix('Request', (ctx) => {
         async () => {
           let actualBody: unknown;
 
-          const handler = vi.fn<RouteHandler>(async (req, res) => {
+          const handler = vi.fn<Handler>(async (req, res) => {
             const result = await req.body();
             actualBody = result.unwrap();
 
@@ -612,7 +612,7 @@ describeMatrix('Request', (ctx) => {
       async (method) => {
         let actualText: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.text();
           actualText = result.unwrap();
 
@@ -644,7 +644,7 @@ describeMatrix('Request', (ctx) => {
         async () => {
           let actualText: unknown;
 
-          const handler = vi.fn<RouteHandler>(async (req, res) => {
+          const handler = vi.fn<Handler>(async (req, res) => {
             const result = await req.text();
             actualText = result.unwrap();
 
@@ -670,7 +670,7 @@ describeMatrix('Request', (ctx) => {
       test('responds with a `415` status code', async () => {
         let actualText: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.text();
           actualText = result.unwrap();
 
@@ -698,7 +698,7 @@ describeMatrix('Request', (ctx) => {
       async (method) => {
         let actualJSON: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.json();
           actualJSON = result.unwrap();
 
@@ -730,7 +730,7 @@ describeMatrix('Request', (ctx) => {
         async () => {
           let actualJSON: unknown;
 
-          const handler = vi.fn<RouteHandler>(async (req, res) => {
+          const handler = vi.fn<Handler>(async (req, res) => {
             const result = await req.json();
             actualJSON = result.unwrap();
 
@@ -756,7 +756,7 @@ describeMatrix('Request', (ctx) => {
       test('responds with a `415` status code', async () => {
         let actualJSON: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.json();
           actualJSON = result.unwrap();
 
@@ -781,7 +781,7 @@ describeMatrix('Request', (ctx) => {
       test('responds with a `422` status code', async () => {
         let actualJSON: unknown;
 
-        const handler = vi.fn<RouteHandler>(async (req, res) => {
+        const handler = vi.fn<Handler>(async (req, res) => {
           const result = await req.json();
           actualJSON = result.unwrap();
 

--- a/test/response.test.ts
+++ b/test/response.test.ts
@@ -1,10 +1,10 @@
-import type { RouteHandler } from '../src/types.js';
+import type { Handler } from '../src/types.js';
 import { describeMatrix } from './_setup.js';
 
 describeMatrix('Response', (ctx) => {
   describe('status()', () => {
     test('responds with the status code', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.status(400);
       });
 
@@ -17,7 +17,7 @@ describeMatrix('Response', (ctx) => {
     });
 
     test('does not overwrite the status code if the response has already been sent', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.status(400);
         res.status(401);
       });
@@ -33,7 +33,7 @@ describeMatrix('Response', (ctx) => {
 
   describe('ok()', () => {
     test('responds with a `200` status code', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -48,7 +48,7 @@ describeMatrix('Response', (ctx) => {
 
   describe('header()', () => {
     test('sets the header', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.header('x-foo', 'bar');
 
         res.ok();
@@ -64,7 +64,7 @@ describeMatrix('Response', (ctx) => {
     });
 
     test('overwrites the header with the latest value of the same key', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.header('x-foo', 'bar');
         res.header('x-foo', 'qux');
 
@@ -81,7 +81,7 @@ describeMatrix('Response', (ctx) => {
     });
 
     test('does not overwrite the header with the latest value if the response has already been sent', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.header('x-foo', 'bar');
 
         res.ok();
@@ -101,7 +101,7 @@ describeMatrix('Response', (ctx) => {
 
   describe('json()', () => {
     test('sends a JSON response', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.json(200, {
           hello: 'world',
           foo: 123,
@@ -124,7 +124,7 @@ describeMatrix('Response', (ctx) => {
     });
 
     test('sends only the status code if the request method is `HEAD`', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.json(200, {
           hello: 'world',
           foo: 123,
@@ -147,7 +147,7 @@ describeMatrix('Response', (ctx) => {
 
   describe('text()', () => {
     test('sends a text response', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.text(200, 'hello');
       });
 
@@ -163,7 +163,7 @@ describeMatrix('Response', (ctx) => {
     });
 
     test('sends only the status code if the request method is `HEAD`', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.text(200, 'hello');
       });
 

--- a/test/zing.test.ts
+++ b/test/zing.test.ts
@@ -1,5 +1,5 @@
 import { HTTPStatusCode } from '../src/http-status-code.js';
-import type { ErrorHandler, HTTPMethod, RouteHandler } from '../src/types.js';
+import type { ErrorHandler, Handler, HTTPMethod } from '../src/types.js';
 import { describeMatrix } from './_setup.js';
 
 describeMatrix('Zing', (ctx) => {
@@ -7,7 +7,7 @@ describeMatrix('Zing', (ctx) => {
     test.each<HTTPMethod>(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'])(
       'adds a route for the method `%s`',
       async (method) => {
-        const handler = vi.fn<RouteHandler>((_, res) => {
+        const handler = vi.fn<Handler>((_, res) => {
           res.ok();
         });
 
@@ -25,7 +25,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('get()', () => {
     test('adds a route for the `GET` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -42,7 +42,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('head()', () => {
     test('adds a route for the `HEAD` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -59,7 +59,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('patch()', () => {
     test('adds a route for the `PATCH` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -76,7 +76,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('post()', () => {
     test('adds a route for the `POST` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -93,7 +93,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('put()', () => {
     test('adds a route for the `PUT` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -110,7 +110,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('delete()', () => {
     test('adds a route for the `DELETE` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -127,7 +127,7 @@ describeMatrix('Zing', (ctx) => {
 
   describe('options()', () => {
     test('adds a route for the `OPTIONS` method', async () => {
-      const handler = vi.fn<RouteHandler>((_, res) => {
+      const handler = vi.fn<Handler>((_, res) => {
         res.ok();
       });
 
@@ -166,7 +166,7 @@ describeMatrix('Zing', (ctx) => {
       test.each<HTTPMethod>(['GET', 'PATCH', 'POST', 'PUT', 'DELETE', 'OPTIONS'])(
         '(%s) responds with a `404` status',
         async (method) => {
-          const handler = vi.fn<RouteHandler>((_, res) => {
+          const handler = vi.fn<Handler>((_, res) => {
             res.json(HTTPStatusCode.NotFound, { message: 'This is a custom 404 handler.' });
           });
 
@@ -182,7 +182,7 @@ describeMatrix('Zing', (ctx) => {
       );
 
       test('(HEAD) responds with a `404` status', async () => {
-        const handler = vi.fn<RouteHandler>((_, res) => {
+        const handler = vi.fn<Handler>((_, res) => {
           res.json(HTTPStatusCode.NotFound, { message: 'Not found' });
         });
 
@@ -203,7 +203,7 @@ describeMatrix('Zing', (ctx) => {
       test.each<HTTPMethod>(['GET', 'PATCH', 'POST', 'PUT', 'DELETE', 'OPTIONS'])(
         '(%s) responds with a `500` status',
         async (method) => {
-          const handler = vi.fn<RouteHandler>(() => {
+          const handler = vi.fn<Handler>(() => {
             throw new Error('Kaboom!');
           });
 
@@ -220,7 +220,7 @@ describeMatrix('Zing', (ctx) => {
       );
 
       test('(HEAD) responds with a `500` status', async () => {
-        const handler = vi.fn<RouteHandler>(() => {
+        const handler = vi.fn<Handler>(() => {
           throw new Error('Kaboom!');
         });
 
@@ -240,7 +240,7 @@ describeMatrix('Zing', (ctx) => {
       test.each<HTTPMethod>(['GET', 'PATCH', 'POST', 'PUT', 'DELETE', 'OPTIONS'])(
         '(%s) responds with a `500` status',
         async (method) => {
-          const handler = vi.fn<RouteHandler>(() => {
+          const handler = vi.fn<Handler>(() => {
             throw new Error('Kaboom!');
           });
 
@@ -266,7 +266,7 @@ describeMatrix('Zing', (ctx) => {
       );
 
       test('(HEAD) responds with a `500` status', async () => {
-        const handler = vi.fn<RouteHandler>(() => {
+        const handler = vi.fn<Handler>(() => {
           throw new Error('Kaboom!');
         });
 
@@ -295,7 +295,7 @@ describeMatrix('Zing', (ctx) => {
       test.each<HTTPMethod>(['GET', 'PATCH', 'POST', 'PUT', 'DELETE', 'OPTIONS'])(
         '(%s) responds with a `500` status',
         async (method) => {
-          const handler = vi.fn<RouteHandler>(() => {
+          const handler = vi.fn<Handler>(() => {
             throw new Error('Kaboom!');
           });
 
@@ -319,7 +319,7 @@ describeMatrix('Zing', (ctx) => {
       );
 
       test('(HEAD) responds with a `500` status', async () => {
-        const handler = vi.fn<RouteHandler>(() => {
+        const handler = vi.fn<Handler>(() => {
           throw new Error('Kaboom!');
         });
 


### PR DESCRIPTION
Renamed the `RouteHandler` type to `Handler` to align with existing naming conventions and improve consistency across the codebase.