### PR TITLE
feat: support parsing and serialising of cookies in requests and responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight HTTP framework for **Node.js**.
 
 ## 🚧 Roadmap
 
-- [ ] Cookies
+- [x] ~~Cookies~~
 - [x] ~~Middleware~~
 - [ ] Server-sent events
 - [ ] Header, query, and body schema validation
@@ -79,6 +79,7 @@ process.on('SIGINT', async () => {
 - [Request.method](#requestmethod)
 - [Request.get()](#requestget)
 - [Request.set()](#requestset)
+- [Request.cookie()](#requestcookie)
 - [Request.param()](#requestparam)
 - [Request.query()](#requestquery)
 - [Request.queries()](#requestqueries)
@@ -90,6 +91,7 @@ process.on('SIGINT', async () => {
 - [Response.finished](#responsefinished)
 - [Response.status()](#responsestatus)
 - [Response.ok()](#responseok)
+- [Response.cookie()](#responsecookie)
 - [Response.json()](#responsejson)
 - [Response.text()](#responsetext)
 - [Response.header()](#responseheader)
@@ -742,6 +744,31 @@ app.get('/', (req, res) => {
 
 [⬆️ Back to top](#-api)
 
+#### Request.cookie()
+
+Returns the value of the given cookie name from the request. If the cookie is not found and no default value is provided, `null` is returned.
+
+**Type**
+
+```ts
+cookie(name: string, defaultValue?: string): string | null;
+```
+
+**Parameters**
+
+- `name` - The name of the cookie to get the value of.
+- `defaultValue` - The default value to return if the cookie is not found.
+
+**Example**
+
+```ts
+app.get('/', (req, res) => {
+  const value = req.cookie('name', 'defaultValue');
+});
+```
+
+[⬆️ Back to top](#-api)
+
 #### Request.param()
 
 Returns the value of the given parameter name from the request. If the parameter is not found and no default value is provided, `null` is returned.
@@ -1020,6 +1047,35 @@ ok(): void;
 ```ts
 app.get('/', (req, res) => {
   res.ok();
+});
+```
+
+[⬆️ Back to top](#-api)
+
+#### Response.cookie()
+
+Sets a cookie on the response.
+
+**Type**
+
+```ts
+cookie(name: string, value: string, options?: CookieOptions): void;
+```
+
+**Parameters**
+
+- `name` - The name of the cookie to set.
+- `value` - The value of the cookie to set.
+- `options` - The options for the cookie.
+
+**Example**
+
+```ts
+app.get('/', (req, res) => {
+  res.cookie('name', 'value', {
+    path: '/',
+    maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+  });
 });
 ```
 

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -1,0 +1,141 @@
+// Reference: https://github.com/jshttp/cookie/blob/master/src/index.ts
+const VALID_COOKIE_NAME_REGEX = /^[\u0021-\u003A\u003C\u003E-\u007E]+$/;
+const VALID_COOKIE_VALUE_REGEX = /^[\u0021-\u003A\u003C-\u007E]*$/;
+
+/**
+ * Parses the cookie string and returns the value of the given cookie name.
+ * If the cookie is not found, `null` is returned.
+ *
+ * @param cookie - The cookie string to parse.
+ * @param name - The name of the cookie to get the value of.
+ */
+export function parse(cookie: string, name: string) {
+  // A quick way to check if the `name` is present in the cookie.
+  if (cookie.indexOf(name) === -1) {
+    return null;
+  }
+
+  for (let kv of cookie.trim().split(';')) {
+    kv = kv.trim();
+
+    const equalPos = kv.indexOf('=');
+    if (equalPos === -1) {
+      continue;
+    }
+
+    const key = kv.slice(0, equalPos).trim();
+    if (key !== name || !VALID_COOKIE_NAME_REGEX.test(key)) {
+      continue;
+    }
+
+    let value = kv.slice(equalPos + 1).trim();
+
+    // Remove double quotes from the cookie value if present.
+    if (value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    }
+
+    if (!VALID_COOKIE_VALUE_REGEX.test(value)) {
+      continue;
+    }
+
+    return decodeURIComponent(value);
+  }
+
+  return null;
+}
+
+/**
+ * The options for serialising a cookie.
+ */
+export interface SerialiseOptions {
+  /**
+   * The path for which the cookie is valid.
+   */
+  path?: string;
+  /**
+   * The domain for which the cookie is valid.
+   */
+  domain?: string;
+  /**
+   * The date and time when the cookie will expire.
+   * If `expires` and `maxAge` are both provided, `maxAge` will take precedence.
+   */
+  expires?: Date;
+  /**
+   * The maximum age of the cookie in seconds.
+   * If `expires` and `maxAge` are both provided, `maxAge` will take precedence.
+   *
+   * - `maxAge` = 0: No `Max-Age` header will be set.
+   * - `maxAge` > 0: The cookie will expire after the given number of seconds.
+   * - `maxAge` < 0: The cookie will expire immediately, equivalent `Max-Age=0`.
+   */
+  maxAge?: number;
+  /**
+   * Whether the cookie is only accessible via HTTPS.
+   */
+  secure?: boolean;
+  /**
+   * Whether the cookie is only accessible via HTTP(S) requests and not via
+   * JavaScript.
+   */
+  httpOnly?: boolean;
+  /**
+   * The `same-site` attribute for the cookie.
+   */
+  sameSite?: 'strict' | 'lax' | 'none';
+}
+
+/**
+ * Serialises the given cookie name and value into a cookie string.
+ *
+ * @param name - The name of the cookie to serialise.
+ * @param value - The value of the cookie to serialise.
+ * @param options - The options to serialise the cookie with.
+ */
+export function serialise(name: string, value: string, options?: SerialiseOptions) {
+  const cookie = [`${name}=${encodeURIComponent(value)}`];
+
+  if (options?.path) {
+    cookie.push(`Path=${options.path}`);
+  }
+
+  if (options?.domain) {
+    cookie.push(`Domain=${options.domain}`);
+  }
+
+  if (options?.expires) {
+    cookie.push(`Expires=${options.expires.toUTCString()}`);
+  }
+
+  if (options?.maxAge) {
+    if (options.maxAge > 0) {
+      cookie.push(`Max-Age=${options.maxAge | 0}`);
+    }
+    if (options.maxAge < 0) {
+      cookie.push('Max-Age=0');
+    }
+  }
+
+  if (options?.secure) {
+    cookie.push('Secure');
+  }
+
+  if (options?.httpOnly) {
+    cookie.push('HttpOnly');
+  }
+
+  switch (options?.sameSite) {
+    case 'strict':
+      cookie.push('SameSite=Strict');
+      break;
+    case 'lax':
+      cookie.push('SameSite=Lax');
+      break;
+    case 'none':
+      cookie.push('SameSite=None');
+      break;
+  }
+
+  return cookie.join('; ');
+}

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 
+import { parse } from './cookie.js';
 import {
   ContentTooLargeError,
   InternalServerError,
@@ -81,6 +82,22 @@ export default class Request {
     }
 
     this.#kv.set(key, value);
+  }
+
+  /**
+   * Returns the value of the given cookie name from the request. If the
+   * cookie is not found and no default value is provided, `null` is returned.
+   *
+   * @param name - The name of the cookie to get the value of.
+   * @param defaultValue - An optional default value to return if the cookie is not found.
+   */
+  cookie(name: string, defaultValue?: string) {
+    const cookie = this.header('cookie');
+    if (!cookie) {
+      return defaultValue ?? null;
+    }
+
+    return parse(cookie, name) ?? defaultValue ?? null;
   }
 
   /**

--- a/src/response.ts
+++ b/src/response.ts
@@ -1,5 +1,7 @@
 import type { ServerResponse } from 'node:http';
 
+import type { SerialiseOptions } from './cookie.js';
+import { serialise } from './cookie.js';
 import { HTTPStatusCode } from './http-status-code.js';
 import type { HTTPHeaderKey, HTTPHeaders, HTTPHeaderValue, JSONObject } from './types.js';
 
@@ -40,6 +42,22 @@ export default class Response {
    */
   ok() {
     this.status(HTTPStatusCode.OK);
+  }
+
+  /**
+   * Sets a cookie on the response. If the response has already been sent,
+   * this method does nothing.
+   *
+   * @param name - The name of the cookie.
+   * @param value - The value of the cookie.
+   * @param options - The options for the cookie.
+   */
+  cookie(name: string, value: string, options?: SerialiseOptions) {
+    if (this.finished) {
+      return;
+    }
+
+    this.node.setHeader('Set-Cookie', serialise(name, value, options));
   }
 
   /**

--- a/test/cookie.test.ts
+++ b/test/cookie.test.ts
@@ -1,0 +1,99 @@
+import { parse, serialise } from '../src/cookie.js';
+
+describe('parse()', () => {
+  test('returns the cookie value when the cookie exists', () => {
+    expect(parse('foo=bar', 'foo')).toBe('bar');
+  });
+
+  test('returns `null` when the cookie does not exist', () => {
+    expect(parse('foo=bar', 'qux')).toBeNull();
+  });
+
+  test('returns `null` when the cookie name is invalid', () => {
+    expect(parse('foo=bar', 'fo o')).toBeNull();
+  });
+
+  test('returns `null` when the cookie value is invalid', () => {
+    expect(parse('foo=ba r', 'foo')).toBeNull();
+  });
+
+  test('returns the cookie value with double quotes removed', () => {
+    expect(parse('foo="bar"', 'foo')).toBe('bar');
+  });
+
+  test('returns the cookie value with decoded URI characters', () => {
+    expect(parse('foo=ba%20r', 'foo')).toBe('ba r');
+  });
+});
+
+describe('serialise()', () => {
+  test('returns the cookie string when no options are provided', () => {
+    expect(serialise('foo', 'bar')).toBe('foo=bar');
+  });
+
+  test('returns the cookie string with encoded URI characters', () => {
+    expect(serialise('foo', 'ba r', { path: '/foo' })).toBe('foo=ba%20r; Path=/foo');
+  });
+
+  test('returns the cookie string with `path` option', () => {
+    expect(serialise('foo', 'bar', { path: '/foo' })).toBe('foo=bar; Path=/foo');
+  });
+
+  test('returns the cookie string with `domain` option', () => {
+    expect(serialise('foo', 'bar', { domain: 'example.com' })).toBe('foo=bar; Domain=example.com');
+  });
+
+  test('returns the cookie string with `expires` option', () => {
+    expect(serialise('foo', 'bar', { expires: new Date('2025-01-01') })).toBe(
+      'foo=bar; Expires=Wed, 01 Jan 2025 00:00:00 GMT',
+    );
+  });
+
+  describe('returns the cookie string with `maxAge` option', () => {
+    test('when `maxAge` is positive', () => {
+      expect(serialise('foo', 'bar', { maxAge: 1000 })).toBe('foo=bar; Max-Age=1000');
+    });
+
+    test('when `maxAge` is negative', () => {
+      expect(serialise('foo', 'bar', { maxAge: -1000 })).toBe('foo=bar; Max-Age=0');
+    });
+
+    test('when `maxAge` is `0`', () => {
+      expect(serialise('foo', 'bar', { maxAge: 0 })).toBe('foo=bar');
+    });
+  });
+
+  test('returns the cookie string with `secure` option', () => {
+    expect(serialise('foo', 'bar', { secure: true })).toBe('foo=bar; Secure');
+  });
+
+  test('returns the cookie string with `httpOnly` option', () => {
+    expect(serialise('foo', 'bar', { httpOnly: true })).toBe('foo=bar; HttpOnly');
+  });
+
+  describe('returns the cookie string with `sameSite` option', () => {
+    test('when `sameSite` is `strict`', () => {
+      expect(serialise('foo', 'bar', { sameSite: 'strict' })).toBe('foo=bar; SameSite=Strict');
+    });
+
+    test('when `sameSite` is `lax`', () => {
+      expect(serialise('foo', 'bar', { sameSite: 'lax' })).toBe('foo=bar; SameSite=Lax');
+    });
+
+    test('when `sameSite` is `none`', () => {
+      expect(serialise('foo', 'bar', { sameSite: 'none' })).toBe('foo=bar; SameSite=None');
+    });
+  });
+
+  test('returns the cookie string with multiple options', () => {
+    expect(
+      serialise('foo', 'bar', {
+        path: '/',
+        domain: 'example.com',
+        secure: true,
+        httpOnly: true,
+        sameSite: 'none',
+      }),
+    ).toBe('foo=bar; Path=/; Domain=example.com; Secure; HttpOnly; SameSite=None');
+  });
+});


### PR DESCRIPTION
This PR introduces support for **parsing** and **serialising** cookies in HTTP requests and responses, providing a consistent and streamlined way to work with cookies across the application.

- **Cookie parsing**  
  Extracts cookies from the `Cookie` header in **incoming requests** and makes them easily accessible in request handlers.  
  Useful for identifying sessions, user preferences, and other client-specific data.

- **Cookie serialising**  
  Converts cookie data into the appropriate `Set-Cookie` header in **outgoing responses**.  
  Ideal for managing login sessions, tracking, and persistent user settings.

### Usage
```ts
app.get('/', (req, res) => {
  // Reading a cookie with an optional default value
  const value = req.cookie('cookie-name', 'default-value')

  // Setting a cookie with options
  res.cookie('cookie-name', 'cookie-value', { path: '/', maxAge: 3600 })
}
```
