### PR TITLE
perf: use string concat instead of array join when serialising cookie

### DIFF
--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -94,48 +94,48 @@ export interface SerialiseOptions {
  * @param options - The options to serialise the cookie with.
  */
 export function serialise(name: string, value: string, options?: SerialiseOptions) {
-  const cookie = [`${name}=${encodeURIComponent(value)}`];
+  let cookie = `${name}=${encodeURIComponent(value)}`;
 
   if (options?.path) {
-    cookie.push(`Path=${options.path}`);
+    cookie += `; Path=${options.path}`;
   }
 
   if (options?.domain) {
-    cookie.push(`Domain=${options.domain}`);
+    cookie += `; Domain=${options.domain}`;
   }
 
   if (options?.expires) {
-    cookie.push(`Expires=${options.expires.toUTCString()}`);
+    cookie += `; Expires=${options.expires.toUTCString()}`;
   }
 
   if (options?.maxAge) {
     if (options.maxAge > 0) {
-      cookie.push(`Max-Age=${options.maxAge | 0}`);
+      cookie += `; Max-Age=${options.maxAge | 0}`;
     }
     if (options.maxAge < 0) {
-      cookie.push('Max-Age=0');
+      cookie += '; Max-Age=0';
     }
   }
 
   if (options?.secure) {
-    cookie.push('Secure');
+    cookie += '; Secure';
   }
 
   if (options?.httpOnly) {
-    cookie.push('HttpOnly');
+    cookie += '; HttpOnly';
   }
 
   switch (options?.sameSite) {
     case 'strict':
-      cookie.push('SameSite=Strict');
+      cookie += '; SameSite=Strict';
       break;
     case 'lax':
-      cookie.push('SameSite=Lax');
+      cookie += '; SameSite=Lax';
       break;
     case 'none':
-      cookie.push('SameSite=None');
+      cookie += '; SameSite=None';
       break;
   }
 
-  return cookie.join('; ');
+  return cookie;
 }


### PR DESCRIPTION
Improve the performance of cookie serialisation by using string concatenation instead of array join.
- **39%** without serialization options  
- **53%** with serialization options

```
runtime: node 23.11.0 (arm64-darwin)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
array join without options    70.95 ns/iter  71.64 ns   ▇█
                     (66.23 ns … 113.04 ns)  90.75 ns ▄ ██▇▃
                    ( 57.92  b … 267.96  b) 162.15  b █▇████▄▂▂▂▂▂▁▁▁▂▂▂▂▁▁

array join with options      183.84 ns/iter 189.25 ns       █▂
                    (163.48 ns … 273.70 ns) 214.26 ns      ▆██
                    (344.84  b … 822.79  b) 589.31  b ▁▂▃▁█████▆▅▄▇▆▅▃▂▂▁▁▁

concat without options        43.31 ns/iter  43.13 ns   █
                      (40.64 ns … 69.62 ns)  59.47 ns   █
                    ( 32.12  b … 155.36  b)  60.20  b ▁▂█▆▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁

concat with options           86.19 ns/iter  88.35 ns    █
                     (78.56 ns … 115.66 ns) 106.92 ns    █   ▅
                    ( 76.04  b … 476.26  b) 291.67  b ▂▄██▅▆▅█▅▂▂▂▂▂▂▂▁▁▁▂▁
```

<details>

<summary>Benchmark code</summary>

```js
import { bench, run } from "mitata";

function serialiseArrayJoin(name, value, options) {
  const cookie = [`${name}=${encodeURIComponent(value)}`];

  if (options?.path) {
    cookie.push(`Path=${options.path}`);
  }

  if (options?.domain) {
    cookie.push(`Domain=${options.domain}`);
  }

  if (options?.expires) {
    cookie.push(`Expires=${options.expires.toUTCString()}`);
  }

  if (options?.maxAge) {
    if (options.maxAge > 0) {
      cookie.push(`Max-Age=${options.maxAge | 0}`);
    }
    if (options.maxAge < 0) {
      cookie.push("Max-Age=0");
    }
  }

  if (options?.secure) {
    cookie.push("Secure");
  }

  if (options?.httpOnly) {
    cookie.push("HttpOnly");
  }

  switch (options?.sameSite) {
    case "strict":
      cookie.push("SameSite=Strict");
      break;
    case "lax":
      cookie.push("SameSite=Lax");
      break;
    case "none":
      cookie.push("SameSite=None");
      break;
  }

  return cookie.join("; ");
}

function serialiseConcat(name, value, options) {
  let cookie = `${name}=${encodeURIComponent(value)}`;

  if (options?.path) {
    cookie += `; Path=${options.path}`;
  }

  if (options?.domain) {
    cookie += `; Domain=${options.domain}`;
  }

  if (options?.expires) {
    cookie += `; Expires=${options.expires.toUTCString()}`;
  }

  if (options?.maxAge) {
    if (options.maxAge > 0) {
      cookie += `; Max-Age=${options.maxAge | 0}`;
    }
    if (options.maxAge < 0) {
      cookie += "; Max-Age=0";
    }
  }

  if (options?.secure) {
    cookie += "; Secure";
  }

  if (options?.httpOnly) {
    cookie += "; HttpOnly";
  }

  switch (options?.sameSite) {
    case "strict":
      cookie += "; SameSite=Strict";
      break;
    case "lax":
      cookie += "; SameSite=Lax";
      break;
    case "none":
      cookie += "; SameSite=None";
      break;
  }

  return cookie;
}

bench("array join without options", () => {
  serialiseArrayJoin("cookie", "chocolate");
});

bench("array join with options", () => {
  serialiseArrayJoin("cookie", "chocolate", {
    path: "/",
    domain: "example.com",
    maxAge: 1000 * 60 * 60 * 24 * 30,
  });
});

bench("concat without options", () => {
  serialiseConcat("cookie", "chocolate");
});

bench("concat with options", () => {
  serialiseConcat("cookie", "chocolate", {
    path: "/",
    domain: "example.com",
    maxAge: 1000 * 60 * 60 * 24 * 30,
  });
});

await run();
```
</details>