### PR TITLE
refactor!: rename `ZingError` to `BaseError`

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,7 +1,7 @@
 /**
- * Base class for all errors in the Zing framework.
+ * Base class for all errors.
  */
-export class ZingError extends Error {
+export class BaseError extends Error {
   constructor(message: string) {
     super(message);
 
@@ -12,7 +12,7 @@ export class ZingError extends Error {
 /**
  * Thrown when the request content is too large.
  */
-export class ContentTooLargeError extends ZingError {
+export class ContentTooLargeError extends BaseError {
   readonly type = 'CONTENT_TOO_LARGE_ERROR';
 
   constructor() {
@@ -23,7 +23,7 @@ export class ContentTooLargeError extends ZingError {
 /**
  * Thrown when the request content type is not supported.
  */
-export class UnsupportedContentTypeError extends ZingError {
+export class UnsupportedContentTypeError extends BaseError {
   readonly type = 'UNSUPPORTED_CONTENT_TYPE_ERROR';
 
   constructor() {
@@ -34,7 +34,7 @@ export class UnsupportedContentTypeError extends ZingError {
 /**
  * Thrown when the request payload is not a valid JSON object.
  */
-export class MalformedJSONError extends ZingError {
+export class MalformedJSONError extends BaseError {
   readonly type = 'MALFORMED_JSON_ERROR';
 
   constructor() {
@@ -45,7 +45,7 @@ export class MalformedJSONError extends ZingError {
 /**
  * Thrown when an unexpected error occurs.
  */
-export class InternalServerError extends ZingError {
+export class InternalServerError extends BaseError {
   readonly type = 'INTERNAL_SERVER_ERROR';
 
   constructor(cause: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ export { default } from './zing.js';
 
 // Others.
 export {
+  BaseError,
   ContentTooLargeError,
   InternalServerError,
   MalformedJSONError,
   UnsupportedContentTypeError,
-  ZingError,
 } from './errors.js';
 export { HTTPStatusCode } from './http-status-code.js';
 export { default as Request } from './request.js';


### PR DESCRIPTION
This PR renames the `ZingError` class to `BaseError` to better reflect its role as the root error class in the system. As this is a public-facing class, this change breaks compatibility with any existing code that imports or references `ZingError`.

```ts
// Before
import { ZingError } from '@transformgovsg/zing';

// After
import { BaseError } from '@transformgovsg/zing';
```