### PR TITLE
feat: add option to configure `maxBodySize` when reading request content

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ process.on('SIGINT', async () => {
 
 ## 🔌 API
 
+- [Zing.constructor()](#zingconstructor)
 - [Zing.listen()](#zinglisten)
 - [Zing.shutdown()](#zingshutdown)
 - [Zing.route()](#zingroute)
@@ -95,6 +96,35 @@ process.on('SIGINT', async () => {
 - [Response.json()](#responsejson)
 - [Response.text()](#responsetext)
 - [Response.header()](#responseheader)
+
+### Zing.constructor()
+
+Creates a new Zing application.
+
+**Type**
+
+```ts
+constructor(options?: Partial<Options>);
+```
+
+**Parameters**
+
+- `options` - The options for the Zing application.
+  - `maxBodySize` - The maximum size of the body of a request. Default: `1_048_576`.
+
+**Example**
+
+```ts
+const app = new Zing();
+```
+
+With custom options:
+
+```ts
+const app = new Zing({ maxBodySize: 4 * 1024 }); // Limit to 4KB.
+```
+
+[⬆️ Back to top](#-api)
 
 ### Zing.listen()
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,15 @@
+export interface Options {
+  /**
+   * The maximum size of the request body in bytes.
+   *
+   * @default 1_048_576
+   */
+  maxBodySize: number;
+}
+
+/**
+ * The default options for Zing.
+ */
+export const DEFAULT_OPTIONS: Options = {
+  maxBodySize: 1_048_576,
+};

--- a/src/zing.ts
+++ b/src/zing.ts
@@ -5,6 +5,8 @@ import type { Socket } from 'node:net';
 
 import { ContentTooLargeError, MalformedJSONError, UnsupportedContentTypeError } from './errors.js';
 import { HTTPStatusCode } from './http-status-code.js';
+import type { Options } from './options.js';
+import { DEFAULT_OPTIONS } from './options.js';
 import Request from './request.js';
 import Response from './response.js';
 import Router from './router.js';
@@ -51,10 +53,16 @@ export default class Zing {
   #fn404Handler: Handler = DEFAULT_404_HANDLER;
   #fnErrorHandler: ErrorHandler = DEFAULT_ERROR_HANDLER;
 
+  #options: Options;
   #server: HTTPServer;
   #router: Router<{ handler: Handler }>;
 
-  constructor() {
+  constructor(options: Partial<Options> = {}) {
+    this.#options = {
+      ...DEFAULT_OPTIONS,
+      ...options,
+    };
+
     this.#server = createHTTPServer(this.#dispatch.bind(this));
     this.#router = new Router();
   }
@@ -280,7 +288,7 @@ export default class Zing {
   }
 
   async #dispatch(nodeReq: IncomingMessage, nodeRes: ServerResponse) {
-    const req = new Request(nodeReq);
+    const req = new Request(nodeReq, this.#options);
     const res = new Response(nodeRes);
 
     try {

--- a/test/_setup.ts
+++ b/test/_setup.ts
@@ -1,5 +1,6 @@
 import getPort from 'get-port';
 
+import type { Options } from '../src/options.js';
 import type { HTTPMethod, JSONObject } from '../src/types.js';
 import Zing from '../src/zing.js';
 
@@ -16,12 +17,20 @@ export function describeMatrix(
   title: string,
   fn: (ctx: { app: Zing; request: RequestFunction }) => Promise<void> | void,
 ) {
+  describeMatrixWithOptions(title, {}, fn);
+}
+
+export function describeMatrixWithOptions(
+  title: string,
+  options: Partial<Options>,
+  fn: (ctx: { app: Zing; request: RequestFunction }) => Promise<void> | void,
+) {
   describe(title, async () => {
     let app: Zing | null = null;
     let request: RequestFunction | null = null;
 
     beforeEach(async () => {
-      app = new Zing();
+      app = new Zing(options);
 
       const port = await getPort();
       await app.listen(port);


### PR DESCRIPTION
Added support for configuring a custom `maxBodySize` when reading request content.

Previously, the limit was hardcoded to `1e6`. It is now configurable, with a new default of `1_048_576` bytes (1 MiB).

```ts
const app = new Zing({ maxBodySize: 4 * 1024 }); // Limit to 4KB.
```