### PR TITLE
fix: export `Options` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { default as Request } from './request.js';
 export { default as Response } from './response.js';
 
 // Types.
+export type { Options } from './options.js';
 export type {
   ErrorHandler,
   Handler,


### PR DESCRIPTION
This PR exports the `Options` type, which was previously omitted from the public API.