### PR TITLE
fix(request)!: replace `Buffer.concat` with manual `Uint8Array` merging in `body()`

### DIFF
--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -830,7 +830,7 @@ describeMatrix('Request', (ctx) => {
         expect(handler).toHaveBeenCalled();
 
         expect(res.status).toBe(200);
-        expect(actualBody).toEqual(Buffer.from('foobar'));
+        expect(actualBody).toEqual(new TextEncoder().encode('foobar'));
       },
     );
 
@@ -1100,7 +1100,7 @@ describeMatrixWithOptions(
           expect(handler).toHaveBeenCalled();
 
           expect(res.status).toBe(200);
-          expect(actualBody).toEqual(Buffer.from('a' + 'a'.repeat(99)));
+          expect(actualBody).toEqual(new TextEncoder().encode('a' + 'a'.repeat(99)));
         },
       );
 


### PR DESCRIPTION
Although the return type of `body()` was declared as `Uint8Array`, it was actually returned a `Buffer` due to the use of `Buffer.concat`. This has been corrected by manually merging the `Uint8Array` chunks, so `body()` now returns the proper type.